### PR TITLE
Allow multiple conditions

### DIFF
--- a/src/DynamicHID/PIDReportHandler.cpp
+++ b/src/DynamicHID/PIDReportHandler.cpp
@@ -192,12 +192,22 @@ void PIDReportHandler::SetEnvelope(USB_FFBReport_SetEnvelope_Output_Data_t* data
 
 void PIDReportHandler::SetCondition(USB_FFBReport_SetCondition_Output_Data_t* data, volatile TEffectState* effect)
 {
-	effect->cpOffset = data->cpOffset;
-	effect->positiveCoefficient = data->positiveCoefficient;
-	effect->negativeCoefficient = data->negativeCoefficient;
-	effect->positiveSaturation = data->positiveSaturation;
-	effect->negativeSaturation = data->negativeSaturation;
-	effect->deadBand = data->deadBand;
+    if (data -> parameterBlockOffset == 0 ) {
+        effect->cpOffset = data->cpOffset;
+        effect->positiveCoefficient = data->positiveCoefficient;
+        effect->negativeCoefficient = data->negativeCoefficient;
+        effect->positiveSaturation = data->positiveSaturation;
+        effect->negativeSaturation = data->negativeSaturation;
+        effect->deadBand = data->deadBand;
+    } else {
+        effect->cpOffsetY = data->cpOffset;
+        effect->positiveCoefficientY = data->positiveCoefficient;
+        effect->negativeCoefficientY = data->negativeCoefficient;
+        effect->positiveSaturationY = data->positiveSaturation;
+        effect->negativeSaturationY = data->negativeSaturation;
+        effect->deadBandY = data->deadBand;
+    }
+
 }
 
 void PIDReportHandler::SetPeriodic(USB_FFBReport_SetPeriodic_Output_Data_t* data, volatile TEffectState* effect)

--- a/src/DynamicHID/PIDReportHandler.cpp
+++ b/src/DynamicHID/PIDReportHandler.cpp
@@ -192,22 +192,13 @@ void PIDReportHandler::SetEnvelope(USB_FFBReport_SetEnvelope_Output_Data_t* data
 
 void PIDReportHandler::SetCondition(USB_FFBReport_SetCondition_Output_Data_t* data, volatile TEffectState* effect)
 {
-    if (data -> parameterBlockOffset == 0 ) {
-        effect->cpOffset = data->cpOffset;
-        effect->positiveCoefficient = data->positiveCoefficient;
-        effect->negativeCoefficient = data->negativeCoefficient;
-        effect->positiveSaturation = data->positiveSaturation;
-        effect->negativeSaturation = data->negativeSaturation;
-        effect->deadBand = data->deadBand;
-    } else {
-        effect->cpOffsetY = data->cpOffset;
-        effect->positiveCoefficientY = data->positiveCoefficient;
-        effect->negativeCoefficientY = data->negativeCoefficient;
-        effect->positiveSaturationY = data->positiveSaturation;
-        effect->negativeSaturationY = data->negativeSaturation;
-        effect->deadBandY = data->deadBand;
-    }
-
+        uint8_t axis = data->parameterBlockOffset; 
+        effect->conditions[axis].cpOffset = data->cpOffset;
+        effect->conditions[axis].positiveCoefficient = data->positiveCoefficient;
+        effect->conditions[axis].negativeCoefficient = data->negativeCoefficient;
+        effect->conditions[axis].positiveSaturation = data->positiveSaturation;
+        effect->conditions[axis].negativeSaturation = data->negativeSaturation;
+        effect->conditions[axis].deadBand = data->deadBand;
 }
 
 void PIDReportHandler::SetPeriodic(USB_FFBReport_SetPeriodic_Output_Data_t* data, volatile TEffectState* effect)

--- a/src/DynamicHID/PIDReportType.h
+++ b/src/DynamicHID/PIDReportType.h
@@ -213,6 +213,15 @@ typedef struct// FFB: PID Pool Feature Report
 #define FRICTION_DEADBAND			0x30
 
 typedef struct {
+	int16_t cpOffset; // -128..127
+	int16_t  positiveCoefficient; // -128..127
+	int16_t  negativeCoefficient; // -128..127
+	uint16_t positiveSaturation;  // -128..127
+	uint16_t negativeSaturation;  // -128..127
+	uint16_t deadBand;  // 0..255
+} TEffectCondition;
+
+typedef struct {
 	volatile uint8_t state;  // see constants <MEffectState_*>
 	uint8_t effectType; //
 	int16_t offset;
@@ -223,19 +232,7 @@ typedef struct {
 	uint8_t directionX; // angle (0=0 .. 255=360deg)
 	uint8_t directionY; // angle (0=0 .. 255=360deg)
 
-	int16_t cpOffset; // -128..127
-	int16_t  positiveCoefficient; // -128..127
-	int16_t  negativeCoefficient; // -128..127
-	uint16_t positiveSaturation;  // -128..127
-	uint16_t negativeSaturation;  // -128..127
-	uint16_t deadBand;  // 0..255
-
-	int16_t cpOffsetY; // -128..127
-	int16_t  positiveCoefficientY; // -128..127
-	int16_t  negativeCoefficientY; // -128..127
-	uint16_t positiveSaturationY;  // -128..127
-	uint16_t negativeSaturationY;  // -128..127
-	uint16_t deadBandY;  // 0..255
+	TEffectCondition conditions[2];
 
 	uint16_t phase;  // 0..255 (=0..359, exp-2)
 	int16_t startMagnitude;

--- a/src/DynamicHID/PIDReportType.h
+++ b/src/DynamicHID/PIDReportType.h
@@ -28,6 +28,7 @@
 #define _PIDREPORTTYPE_H
 
 #define MAX_EFFECTS 14
+#define FFB_AXIS_COUNT 2
 #define SIZE_EFFECT sizeof(TEffectState)
 #define MEMORY_SIZE (uint16_t)(MAX_EFFECTS*SIZE_EFFECT)
 #define TO_LT_END_16(x) ((x<<8)&0xFF00)|((x>>8)&0x00FF)
@@ -232,7 +233,7 @@ typedef struct {
 	uint8_t directionX; // angle (0=0 .. 255=360deg)
 	uint8_t directionY; // angle (0=0 .. 255=360deg)
 
-	TEffectCondition conditions[2];
+	TEffectCondition conditions[FFB_AXIS_COUNT];
 
 	uint16_t phase;  // 0..255 (=0..359, exp-2)
 	int16_t startMagnitude;

--- a/src/DynamicHID/PIDReportType.h
+++ b/src/DynamicHID/PIDReportType.h
@@ -222,12 +222,21 @@ typedef struct {
 	uint8_t enableAxis; // bits: 0=X, 1=Y, 2=DirectionEnable
 	uint8_t directionX; // angle (0=0 .. 255=360deg)
 	uint8_t directionY; // angle (0=0 .. 255=360deg)
+
 	int16_t cpOffset; // -128..127
 	int16_t  positiveCoefficient; // -128..127
 	int16_t  negativeCoefficient; // -128..127
 	uint16_t positiveSaturation;  // -128..127
 	uint16_t negativeSaturation;  // -128..127
 	uint16_t deadBand;  // 0..255
+
+	int16_t cpOffsetY; // -128..127
+	int16_t  positiveCoefficientY; // -128..127
+	int16_t  negativeCoefficientY; // -128..127
+	uint16_t positiveSaturationY;  // -128..127
+	uint16_t negativeSaturationY;  // -128..127
+	uint16_t deadBandY;  // 0..255
+
 	uint16_t phase;  // 0..255 (=0..359, exp-2)
 	int16_t startMagnitude;
 	int16_t  endMagnitude;

--- a/src/Joystick.cpp
+++ b/src/Joystick.cpp
@@ -493,23 +493,20 @@ void Joystick_::getForce(int32_t* forces) {
 int32_t Joystick_::getEffectForce(volatile TEffectState& effect,Gains _gains,EffectParams _effect_params, uint8_t axis){
 
     uint8_t direction;
+    uint8_t condition;
     if (effect.enableAxis == DIRECTION_ENABLE)
     {
         direction = effect.directionX;
+        condition = 0; // If the Direction Enable flag is set, only one Condition Parameter Block is defined
     }
     else
     {
         direction = axis == 0 ? effect.directionX : effect.directionY;
+        condition = axis;
     }
 
-    float angle;
-    angle = (direction * 360.0 / 255.0) * DEG_TO_RAD;
-    float angle_ratio;
-    if (axis == 0) {
-        angle_ratio = sin(angle);
-    } else {
-        angle_ratio = -1 * cos(angle);
-    }
+    float angle = (direction * 360.0 / 255.0) * DEG_TO_RAD;
+    float angle_ratio = axis == 0 ? sin(angle) : -1 * cos(angle);
 
 	int32_t force = 0;
 	switch (effect.effectType)
@@ -536,21 +533,21 @@ int32_t Joystick_::getEffectForce(volatile TEffectState& effect,Gains _gains,Eff
 	    	force = SawtoothUpForceCalculator(effect) * _gains.sawtoothupGain * angle_ratio;
 	    	break;
 	    case USB_EFFECT_SPRING://8
-	    	force = ConditionForceCalculator(effect, NormalizeRange(_effect_params.springPosition, _effect_params.springMaxPosition), axis) * _gains.springGain;
+	    	force = ConditionForceCalculator(effect, NormalizeRange(_effect_params.springPosition, _effect_params.springMaxPosition), condition) * _gains.springGain;
 	    	break;
 	    case USB_EFFECT_DAMPER://9
-	    	force = ConditionForceCalculator(effect, NormalizeRange(_effect_params.damperVelocity, _effect_params.damperMaxVelocity), axis) * _gains.damperGain;
+	    	force = ConditionForceCalculator(effect, NormalizeRange(_effect_params.damperVelocity, _effect_params.damperMaxVelocity), condition) * _gains.damperGain;
 	    	break;
 	    case USB_EFFECT_INERTIA://10
 	    	if (_effect_params.inertiaAcceleration < 0 && _effect_params.frictionPositionChange < 0) {
-	    		force = ConditionForceCalculator(effect, abs(NormalizeRange(_effect_params.inertiaAcceleration, _effect_params.inertiaMaxAcceleration)), axis) * _gains.inertiaGain;
+	    		force = ConditionForceCalculator(effect, abs(NormalizeRange(_effect_params.inertiaAcceleration, _effect_params.inertiaMaxAcceleration)), condition) * _gains.inertiaGain;
 	    	}
 	    	else if (_effect_params.inertiaAcceleration < 0 && _effect_params.frictionPositionChange > 0) {
-	    		force = -1 * ConditionForceCalculator(effect, abs(NormalizeRange(_effect_params.inertiaAcceleration, _effect_params.inertiaMaxAcceleration)), axis) * _gains.inertiaGain;
+	    		force = -1 * ConditionForceCalculator(effect, abs(NormalizeRange(_effect_params.inertiaAcceleration, _effect_params.inertiaMaxAcceleration)), condition) * _gains.inertiaGain;
 	    	}
 	    	break;
 	    case USB_EFFECT_FRICTION://11
-	    		force = ConditionForceCalculator(effect, NormalizeRange(_effect_params.frictionPositionChange, _effect_params.frictionMaxPositionChange), axis) * _gains.frictionGain;
+	    		force = ConditionForceCalculator(effect, NormalizeRange(_effect_params.frictionPositionChange, _effect_params.frictionMaxPositionChange), condition) * _gains.frictionGain;
 	    		break;
 	    case USB_EFFECT_CUSTOM://12
 	    		break;

--- a/src/Joystick.cpp
+++ b/src/Joystick.cpp
@@ -710,36 +710,27 @@ int32_t Joystick_::ConditionForceCalculator(volatile TEffectState& effect, float
     float positiveSaturation;
     float positiveCoefficient;
 
-    if (axis == 0) {
-        deadBand = effect.deadBand;
-        cpOffset = effect.cpOffset;
-        negativeCoefficient = -effect.negativeCoefficient;
-        negativeSaturation = -effect.negativeSaturation;
-        positiveSaturation = effect.positiveSaturation;
-        positiveCoefficient = effect.positiveCoefficient;
-    } else {
-        deadBand = effect.deadBandY;
-        cpOffset = effect.cpOffsetY;
-        negativeCoefficient = -effect.negativeCoefficientY;
-        negativeSaturation = -effect.negativeSaturationY;
-        positiveSaturation = effect.positiveSaturationY;
-        positiveCoefficient = effect.positiveCoefficientY;
-    }
+    deadBand = effect.conditions[axis].deadBand;
+    cpOffset = effect.conditions[axis].cpOffset;
+    negativeCoefficient = effect.conditions[axis].negativeCoefficient;
+    negativeSaturation = effect.conditions[axis].negativeSaturation;
+    positiveSaturation = effect.conditions[axis].positiveSaturation;
+    positiveCoefficient = effect.conditions[axis].positiveCoefficient;
 
     float  tempForce = 0;
 
 	if (metric < (cpOffset - deadBand)) {
-		//    float tempForce = (metric - (float)1.00*(cpOffset - deadBand)/10000) * negativeCoefficient;
-		tempForce = ((float)1.00 * (cpOffset - deadBand) / 10000 - metric) * negativeCoefficient;
-		//    tempForce = (tempForce < negativeSaturation ? negativeSaturation : tempForce); I dont know why negativeSaturation = 55536.00 after negativeSaturation = -effect.negativeSaturation;
-		tempForce = (tempForce < (-effect.negativeCoefficient) ? (-effect.negativeCoefficient) : tempForce);
+		tempForce = (metric - (float)1.00*(cpOffset - deadBand)/10000) * negativeCoefficient;
+		// tempForce = ((float)1.00 * (cpOffset - deadBand) / 10000 - metric) * negativeCoefficient;
+		   tempForce = (tempForce < -negativeSaturation ? -negativeSaturation : tempForce); // I dont know why negativeSaturation = 55536.00 after negativeSaturation = -effect.negativeSaturation;
+		// tempForce = (tempForce < (-effect.negativeCoefficient) ? (-effect.negativeCoefficient) : tempForce);
 	}
 	else if (metric > (cpOffset + deadBand)) {
 		tempForce = (metric - (float)1.00 * (cpOffset + deadBand) / 10000) * positiveCoefficient;
 		tempForce = (tempForce > positiveSaturation ? positiveSaturation : tempForce);
 	}
 	else return 0;
-	tempForce = tempForce * effect.gain / 255;
+	tempForce = -tempForce * effect.gain / 255;
 	switch (effect.effectType) {
 	case  USB_EFFECT_DAMPER:
 		//tempForce = damperFilter.filterIn(tempForce);

--- a/src/Joystick.h
+++ b/src/Joystick.h
@@ -161,9 +161,9 @@ private:
 	int32_t TriangleForceCalculator(volatile TEffectState& effect);
 	int32_t SawtoothDownForceCalculator(volatile TEffectState& effect);
 	int32_t SawtoothUpForceCalculator(volatile TEffectState& effect);
-	int32_t ConditionForceCalculator(volatile TEffectState& effect, float metric);
+	int32_t ConditionForceCalculator(volatile TEffectState& effect, float metric, uint8_t axis);
 	void forceCalculator(int32_t* forces);
-	int32_t getEffectForce(volatile TEffectState& effect, Gains _gains, EffectParams _effect_params);
+	int32_t getEffectForce(volatile TEffectState& effect, Gains _gains, EffectParams _effect_params, float angle, uint8_t axis);
 protected:
 	int buildAndSet16BitValue(bool includeValue, int16_t value, int16_t valueMinimum, int16_t valueMaximum, int16_t actualMinimum, int16_t actualMaximum, uint8_t dataLocation[]);
 	int buildAndSetAxisValue(bool includeAxis, int16_t axisValue, int16_t axisMinimum, int16_t axisMaximum, uint8_t dataLocation[]);

--- a/src/Joystick.h
+++ b/src/Joystick.h
@@ -163,7 +163,7 @@ private:
 	int32_t SawtoothUpForceCalculator(volatile TEffectState& effect);
 	int32_t ConditionForceCalculator(volatile TEffectState& effect, float metric, uint8_t axis);
 	void forceCalculator(int32_t* forces);
-	int32_t getEffectForce(volatile TEffectState& effect, Gains _gains, EffectParams _effect_params, float angle, uint8_t axis);
+	int32_t getEffectForce(volatile TEffectState& effect, Gains _gains, EffectParams _effect_params, uint8_t axis);
 protected:
 	int buildAndSet16BitValue(bool includeValue, int16_t value, int16_t valueMinimum, int16_t valueMaximum, int16_t actualMinimum, int16_t actualMaximum, uint8_t dataLocation[]);
 	int buildAndSetAxisValue(bool includeAxis, int16_t axisValue, int16_t axisMinimum, int16_t axisMaximum, uint8_t dataLocation[]);


### PR DESCRIPTION
This allows multiple conditions so that when we have a multi-axis device we can track the forces and offsets separately for the x and y axes. This fixes #14