### PR TITLE
Condition Effects Fix

### DIFF
--- a/src/DynamicHID/PIDReportHandler.cpp
+++ b/src/DynamicHID/PIDReportHandler.cpp
@@ -199,6 +199,7 @@ void PIDReportHandler::SetCondition(USB_FFBReport_SetCondition_Output_Data_t* da
         effect->conditions[axis].positiveSaturation = data->positiveSaturation;
         effect->conditions[axis].negativeSaturation = data->negativeSaturation;
         effect->conditions[axis].deadBand = data->deadBand;
+		effect->conditionBlocksCount++;
 }
 
 void PIDReportHandler::SetPeriodic(USB_FFBReport_SetPeriodic_Output_Data_t* data, volatile TEffectState* effect)

--- a/src/DynamicHID/PIDReportType.h
+++ b/src/DynamicHID/PIDReportType.h
@@ -232,6 +232,7 @@ typedef struct {
 	uint8_t enableAxis; // bits: 0=X, 1=Y, 2=DirectionEnable
 	uint8_t directionX; // angle (0=0 .. 255=360deg)
 	uint8_t directionY; // angle (0=0 .. 255=360deg)
+	uint8_t conditionBlocksCount;
 
 	TEffectCondition conditions[FFB_AXIS_COUNT];
 

--- a/src/Joystick.cpp
+++ b/src/Joystick.cpp
@@ -494,10 +494,17 @@ int32_t Joystick_::getEffectForce(volatile TEffectState& effect,Gains _gains,Eff
 
     uint8_t direction;
     uint8_t condition;
+
+	bool useForceDirectionForConditionEffect = (effect.enableAxis == DIRECTION_ENABLE && effect.conditionsCount == 1);
+
     if (effect.enableAxis == DIRECTION_ENABLE)
     {
         direction = effect.directionX;
-        condition = 0; // If the Direction Enable flag is set, only one Condition Parameter Block is defined
+		if (effect.conditionsCount > 1) {
+            condition = axis;
+        } else {
+	        condition = 0; // only one Condition Parameter Block is defined
+		}
     }
     else
     {
@@ -534,9 +541,15 @@ int32_t Joystick_::getEffectForce(volatile TEffectState& effect,Gains _gains,Eff
 	    	break;
 	    case USB_EFFECT_SPRING://8
 	    	force = ConditionForceCalculator(effect, NormalizeRange(_effect_params.springPosition, _effect_params.springMaxPosition), condition) * _gains.springGain;
+			if (useForceDirectionForConditionEffect) {
+				force *= angle_ratio;
+			}
 	    	break;
 	    case USB_EFFECT_DAMPER://9
 	    	force = ConditionForceCalculator(effect, NormalizeRange(_effect_params.damperVelocity, _effect_params.damperMaxVelocity), condition) * _gains.damperGain;
+			if (useForceDirectionForConditionEffect) {
+				force *= angle_ratio;
+			}
 	    	break;
 	    case USB_EFFECT_INERTIA://10
 	    	if (_effect_params.inertiaAcceleration < 0 && _effect_params.frictionPositionChange < 0) {
@@ -545,9 +558,15 @@ int32_t Joystick_::getEffectForce(volatile TEffectState& effect,Gains _gains,Eff
 	    	else if (_effect_params.inertiaAcceleration < 0 && _effect_params.frictionPositionChange > 0) {
 	    		force = -1 * ConditionForceCalculator(effect, abs(NormalizeRange(_effect_params.inertiaAcceleration, _effect_params.inertiaMaxAcceleration)), condition) * _gains.inertiaGain;
 	    	}
+			if (useForceDirectionForConditionEffect) {
+				force *= angle_ratio;
+			}
 	    	break;
 	    case USB_EFFECT_FRICTION://11
-	    		force = ConditionForceCalculator(effect, NormalizeRange(_effect_params.frictionPositionChange, _effect_params.frictionMaxPositionChange), condition) * _gains.frictionGain;
+	    	force = ConditionForceCalculator(effect, NormalizeRange(_effect_params.frictionPositionChange, _effect_params.frictionMaxPositionChange), condition) * _gains.frictionGain;
+			if (useForceDirectionForConditionEffect) {
+				force *= angle_ratio;
+			}
 	    		break;
 	    case USB_EFFECT_CUSTOM://12
 	    		break;


### PR DESCRIPTION
There is a problem in the effects calculator. It doesn't correctly implement the PID specification:

If the number of Condition report blocks is equal to the number of axes for the effect, then the first report
block applies to the first axis, the second applies to the second axis, and so on. For example, a two-axis
spring condition with CP Offset set to zero in both Condition report blocks would have the same effect as
the joystick self-centering spring. When a condition is defined for each axis in this way, the effect must
not be rotated.

If there is a single Condition report block for an effect with more than one axis, then the direction along
which the parameters of the Condition report block are in effect is determined by the direction parameters
passed in the Direction field of the Effect report block. For example, a friction condition rotated 45
degrees (in polar coordinates) would resist joystick motion in the northeast-southwest direction but would
have no effect on joystick motion in the northwest-southeast direction.

The spring effect is being sent with the DIRECTION_ENABLE flag set (not individual axis enable bits) but with 2 parameter blocks (X & Y). The code is seeing DIRECTION_ENABLE & setting condition var to zero so it's only applying the first parameter block, regardless of the axis i.e. the Y axis is using the X axis parameter block. The code needs to count the number of parameter blocks set (as the effect get's built from the HID reports) & if more than one block, apply the relevant parameter block to each axis. If there is only one parameter block, then the effect needs to be scaled by the angle_ratio. (paragraph 2)
I had the same problem developing multi-axis code for OpenFFBoard &, after studying the HID reports using USBlyzer & the output from FEdit.exe, this is the fix. Now in XPlane, when I trim the cpOffset moves the pitch (Y) axis correctly. Luckily, it's an easy fix.

 On branch conditionEffect
 Changes to be committed:
	modified:   src/DynamicHID/PIDReportHandler.cpp
	modified:   src/DynamicHID/PIDReportType.h
	modified:   src/Joystick.cpp