### PR TITLE
Fixed infinite effects duration

### DIFF
--- a/src/DynamicHID/PIDReportType.h
+++ b/src/DynamicHID/PIDReportType.h
@@ -195,7 +195,7 @@ typedef struct {
 } TEffectCondition;
 
 ///effect
-#define USB_DURATION_INFINITE		0x7FFF
+#define USB_DURATION_INFINITE		0xFFFF
 
 #define USB_EFFECT_CONSTANT	  		0x01
 #define USB_EFFECT_RAMP				0x02


### PR DESCRIPTION
The `USB_DURATION_INFINITE` was set to `0x7FFF` but the `elapsedTime` goes up to `0xFFFF`. This resulted in an infinite duration effect cutting out for ~32 seconds every ~32 seconds. 

Setting the `USB_DURATION_INFINITE` to the same value as the maximum `elapsedTime` fixes this issue.